### PR TITLE
Updates deployment to use Surge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ open http://localhost:9000
 
 ## Deploying
 
-We are currently using an unconventional method of deploying to the Harp Platform. You’ll need to have access to the project on the Harp Platform and the Dropbox shared with you to deploy. Follow the [Running locally](#running-locally) instructions, and then:
+Follow the [Running locally](#running-locally) instructions. You’ll need to be a collaborator on the project through Surge to deploy. Then:
 
 ```bash
-# Compile to your Dropbox
+# Compile to www/ and deploy
 npm run deploy
 ```
-
-Now, just press Publish on the chloi.io project on the [Harp Platform](http://harp.io).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "chloi.io",
   "version": "2.0.0",
   "private": true,
+  "homepage": "http://chloi.io",
   "dependencies": {
+  },
+  "devDependencies": {
+    "surge": "*"
   },
   "scripts": {
     "start": "harp server",
-    "deploy": "harp compile . ~/Dropbox/harp.io/apps/chloi.harp.io/public && rm -rf ~/Dropbox/harp.io/apps/chloi.harp.io/public/node_modules"
+    "compile": "harp compile",
+    "deploy": "npm run compile && surge ./www chloi.io"
   }
 }


### PR DESCRIPTION
Once the chloi.io domain is updated to Surge’s IP, `192.241.214.148`, then `npm run deploy` will build and deploy the site. We probably want to wait on this until collaborators are supported in Surge.
